### PR TITLE
fix: Export `DaikinButton`

### DIFF
--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,1 +1,1 @@
-import './daikin-button';
+export { default as DaikinButton } from './daikin-button';


### PR DESCRIPTION
Fix to export DaikinButton to allow DDS to be used with React.