### PR TITLE
Fix react interaction test not working at all

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint": "npm run lint:code && npm run lint:lit && npm run lint:cspell && npm run lint:ls",
     "lint-fix": "eslint --fix && prettier -w .",
     "test:interaction-wc": "start-server-and-test storybook:ci-wc http://localhost:6099 \"npx test-storybook --url http://localhost:6099\"",
-    "test:interaction-react": "start-server-and-test storybook:ci-wc http://localhost:6099 \"npx test-storybook --url http://localhost:6099\"",
+    "test:interaction-react": "start-server-and-test storybook:ci-react http://localhost:6099 \"npx test-storybook --url http://localhost:6099\"",
     "test:interaction": "npm run test:interaction-wc && npm run test:interaction-react",
     "test:visual-wc": "cross-env STORYBOOK_FW=web-components playwright test",
     "test:visual-react": "cross-env STORYBOOK_FW=react playwright test",

--- a/src/components/button/stories/common.ts
+++ b/src/components/button/stories/common.ts
@@ -8,6 +8,7 @@ export interface DaikinButtonStoryArgs
    * Text input for users
    */
   label: string;
+  onClick: (event: Event) => void;
 }
 
 export const DAIKIN_BUTTON_ARG_TYPES = {

--- a/src/components/button/stories/framework-react.tsx
+++ b/src/components/button/stories/framework-react.tsx
@@ -9,7 +9,7 @@ const ReactDaikinButton = createComponent({
   tagName: "daikin-button",
   elementClass: DaikinButton,
   events: {
-    click: "onClick",
+    onClick: "click",
   },
 });
 

--- a/src/components/checkbox/stories/common.ts
+++ b/src/components/checkbox/stories/common.ts
@@ -2,7 +2,11 @@ import type { DaikinCheckbox } from "#package/components/checkbox/daikin-checkbo
 import type { ElementProps } from "#storybook";
 import type { Meta, StoryObj } from "@storybook/web-components";
 
-export type DaikinCheckboxStoryArgs = Required<ElementProps<DaikinCheckbox>>;
+export interface DaikinCheckboxStoryArgs
+  extends Required<ElementProps<DaikinCheckbox>> {
+  onChange: (event: Event) => void;
+  onClick: (event: Event) => void;
+}
 
 export const DAIKIN_CHECKBOX_ARG_TYPES = {
   size: {

--- a/src/components/checkbox/stories/framework-react.tsx
+++ b/src/components/checkbox/stories/framework-react.tsx
@@ -9,8 +9,8 @@ const ReactDaikinCheckbox = createComponent({
   tagName: "daikin-checkbox",
   elementClass: DaikinCheckbox,
   events: {
-    change: "onChange",
-    click: "onClick",
+    onChange: "change",
+    onClick: "click",
   },
 });
 

--- a/src/components/notification/stories/framework-react.tsx
+++ b/src/components/notification/stories/framework-react.tsx
@@ -9,7 +9,7 @@ const ReactDaikinNotification = createComponent({
   elementClass: DaikinNotification,
   react: React,
   events: {
-    close: "onClose",
+    onClose: "close",
   },
 });
 

--- a/src/storybook/type-utils.ts
+++ b/src/storybook/type-utils.ts
@@ -1,35 +1,10 @@
 import type { WebComponentProps } from "@lit/react";
 
-type Uppercase =
-  | "A"
-  | "B"
-  | "C"
-  | "D"
-  | "E"
-  | "F"
-  | "G"
-  | "H"
-  | "I"
-  | "J"
-  | "K"
-  | "L"
-  | "M"
-  | "N"
-  | "O"
-  | "P"
-  | "Q"
-  | "R"
-  | "S"
-  | "T"
-  | "U"
-  | "V"
-  | "W"
-  | "X"
-  | "Y"
-  | "Z";
-
 // regex: /^on[A-Z]/
-type EventListenerKeys<K> = K extends `on${Uppercase}${string}` ? K : never;
+// Note that `Capitalize<string>` includes strings that contain uppercase letters from the second character onwards. (e.g. `KeyDown`)
+type EventListenerKeys<K> = K extends `on${Capitalize<string>}${string}`
+  ? K
+  : never;
 
 // T without /^on[A-Z]/ props
 type OmitEventListeners<T> = Omit<T, EventListenerKeys<keyof T>>;

--- a/src/storybook/type-utils.ts
+++ b/src/storybook/type-utils.ts
@@ -1,12 +1,37 @@
 import type { WebComponentProps } from "@lit/react";
 
-// A to Z
-type Uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[number];
+type Uppercase =
+  | "A"
+  | "B"
+  | "C"
+  | "D"
+  | "E"
+  | "F"
+  | "G"
+  | "H"
+  | "I"
+  | "J"
+  | "K"
+  | "L"
+  | "M"
+  | "N"
+  | "O"
+  | "P"
+  | "Q"
+  | "R"
+  | "S"
+  | "T"
+  | "U"
+  | "V"
+  | "W"
+  | "X"
+  | "Y"
+  | "Z";
 
-// regex: /^on[A-Z].*$/
+// regex: /^on[A-Z]/
 type EventListenerKeys<K> = K extends `on${Uppercase}${string}` ? K : never;
 
-// T without on* props
+// T without /^on[A-Z]/ props
 type OmitEventListeners<T> = Omit<T, EventListenerKeys<keyof T>>;
 
 export type ElementProps<T extends HTMLElement> = OmitEventListeners<

--- a/src/storybook/type-utils.ts
+++ b/src/storybook/type-utils.ts
@@ -2,9 +2,7 @@ import type { WebComponentProps } from "@lit/react";
 
 // regex: /^on[A-Z]/
 // Note that `Capitalize<string>` includes strings that contain uppercase letters from the second character onwards. (e.g. `KeyDown`)
-type EventListenerKeys<K> = K extends `on${Capitalize<string>}${string}`
-  ? K
-  : never;
+type EventListenerKeys<K> = K extends `on${Capitalize<string>}` ? K : never;
 
 // T without /^on[A-Z]/ props
 type OmitEventListeners<T> = Omit<T, EventListenerKeys<keyof T>>;

--- a/src/storybook/type-utils.ts
+++ b/src/storybook/type-utils.ts
@@ -1,3 +1,9 @@
 import type { WebComponentProps } from "@lit/react";
 
-export type ElementProps<T extends HTMLElement> = WebComponentProps<T>;
+type EventListenerKeys<K> =
+  K extends `on${"ABCDEFGHIJKLMNOPQRSTUVWXYZ"[number]}${string}` ? K : never;
+type OmitEventListeners<T> = Omit<T, EventListenerKeys<keyof T>>;
+
+export type ElementProps<T extends HTMLElement> = OmitEventListeners<
+  WebComponentProps<T>
+>;

--- a/src/storybook/type-utils.ts
+++ b/src/storybook/type-utils.ts
@@ -1,7 +1,12 @@
 import type { WebComponentProps } from "@lit/react";
 
-type EventListenerKeys<K> =
-  K extends `on${"ABCDEFGHIJKLMNOPQRSTUVWXYZ"[number]}${string}` ? K : never;
+// A to Z
+type Uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[number];
+
+// regex: /^on[A-Z].*$/
+type EventListenerKeys<K> = K extends `on${Uppercase}${string}` ? K : never;
+
+// T without on* props
 type OmitEventListeners<T> = Omit<T, EventListenerKeys<keyof T>>;
 
 export type ElementProps<T extends HTMLElement> = OmitEventListeners<


### PR DESCRIPTION
There was a typo in `test:interaction-react` command.

## Checklist

- [x] Confirmed `npm run test:interaction-react` works on local machine.
- [x] Confirmed that the following strings are included in the CI interaction test logs, indicating that we are testing in all environments.
  - `Storybook x.y.z for web-components-vite started` (storybook common wc)
  - `Storybook x.y.z for react-vite started` (storybook common react)
  - `[storybook-vite] Using development code of web-components component` (dev wc)
  - `[storybook-vite] Using development code of react component` (dev react)
  - `> npx http-server -s -c-1 -d false --no-dotfiles -p 6099 storybook-static/web-components` (prod wc)
  - `> npx http-server -s -c-1 -d false --no-dotfiles -p 6099 storybook-static/react` (prod react)