### PR TITLE
DDS-1462 Delete stories area from component docs

### DIFF
--- a/.changeset/beige-items-destroy.md
+++ b/.changeset/beige-items-destroy.md
@@ -1,0 +1,5 @@
+---
+"@daikin-oss/design-system-web-components": patch
+---
+
+Delete Stories area from component documentation page.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,3 +1,10 @@
+import {
+  Controls,
+  Description,
+  Primary,
+  Subtitle,
+  Title,
+} from "@storybook/blocks";
 import { useGlobals } from "@storybook/preview-api";
 import type { Preview } from "@storybook/web-components";
 
@@ -53,6 +60,17 @@ const preview: Preview = {
         color: /(background|color)$/i,
         date: /Date$/,
       },
+    },
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Primary />
+          <Controls />
+        </>
+      ),
     },
   },
   globalTypes: {

--- a/.storybook/react/preview.tsx
+++ b/.storybook/react/preview.tsx
@@ -1,6 +1,12 @@
+import {
+  Controls,
+  Description,
+  Primary,
+  Subtitle,
+  Title,
+} from "@storybook/blocks";
 import type { Preview } from "@storybook/react";
 import React from "react";
-
 import "../preview-common";
 
 const preview: Preview = {
@@ -10,6 +16,17 @@ const preview: Preview = {
         color: /(background|color)$/i,
         date: /Date$/,
       },
+    },
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Primary />
+          <Controls />
+        </>
+      ),
     },
   },
 };


### PR DESCRIPTION
<!-- Make sure PR name is like the following -->
<!-- DDS-XXXX [Component Name 1, Component Name 2] Fix ... -->

## Related Ticket(s) and Links

<!-- Uncomment and fill in the issue number below, if any. -->
<!-- Closes #XXX. -->

<!-- Fill in the links below, if applicable. -->

- JIRA Ticket: [DDS-1462](https://daikinsvoil.atlassian.net/browse/DDS-1462)

## Problem

Since users can interact by change the values, Stories in docs may be redundant.

## Solution

delete stories area from docs

## How Has This Been Tested?

- Confirm every component's docs page without Stories area (react pattern and web component pattern), and others place not be changed.

## Checklist

- [x] I have added a changeset file that describes the changes.
      _Hint_: run `npx changeset`.
- [x] I have performed a self-review of my code.
- [x] I have added/updated appropriate regression tests.
- [x] I have confirmed that there are no accessibility warnings that can be addressed.
      _Hint_: check the Accessibility tab in the Storybook.
- [x] I have confirmed that the bug fix does not affect the keyboard accessibility of the component.
- [x] I have confirmed that the fix does not introduce any new visual regressions.

<!-- Testing and linting are not in this checklist, as they are performed by GitHub Actions. -->

If you don't feel that the PR is ready for review, please create the PR in draft status.
