### PR TITLE
Fix TS4094 Error

### DIFF
--- a/src/controllers/helpers/controller-directive.ts
+++ b/src/controllers/helpers/controller-directive.ts
@@ -1,5 +1,9 @@
 import { nothing, type Part } from "lit";
-import { AsyncDirective, directive } from "lit/async-directive.js";
+import {
+  AsyncDirective,
+  directive,
+  type DirectiveResult,
+} from "lit/async-directive.js";
 
 function argsChanged(
   current: readonly unknown[],
@@ -27,7 +31,7 @@ export function createControllerDirective<T extends unknown[]>(
     newArgs: NoInfer<T>,
     oldArgs: NoInfer<T>
   ) => boolean = argsChanged
-) {
+): (...values: T) => DirectiveResult {
   class ControllerDirective extends AsyncDirective {
     /** The arguments passed to render. */
     private _args: T | undefined;


### PR DESCRIPTION
<!-- Make sure PR name is like the following -->
<!-- DDS-XXXX [Component Name 1, Component Name 2] Fix ... -->

## Related Ticket(s) and Links

N/A

## Problem

Although it is unclear when this started, TS4094 errors were occurring when building the type declaration file.
This PR fixes that error.

## Root Cause

The `createControllerDirective` function was being inferred to include an anonymous class in the return type, and since that anonymous class could not be expressed in the type declaration, it was causing an error.

## Solution

This was resolved by adding an explicit return type declaration to the function.

## How Has This Been Tested?

`npm run build`.

## Checklist

I think we don't need a changeset for this PR.

- [ ] I have added a changeset file that describes the changes.
      _Hint_: run `npx changeset`.
- [x] I have performed a self-review of my code.
- [x] I have added/updated appropriate regression tests.
- [x] I have confirmed that there are no accessibility warnings that can be addressed.
      _Hint_: check the Accessibility tab in the Storybook.
- [x] I have confirmed that the bug fix does not affect the keyboard accessibility of the component.
- [x] I have confirmed that the fix does not introduce any new visual regressions.
